### PR TITLE
Use team alias for approvers/reviewers over direct members

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,15 +1,6 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
-  - ascerra
-  - minlei98
-  - ryankwilliams
-  - vi-patel
-  - madunn
-options: {}
+  - cspi-qe-ocp-lp
 reviewers:
-  - ascerra
-  - minlei98
-  - ryankwilliams
-  - vi-patel
-  - madunn
+  - cspi-qe-ocp-lp


### PR DESCRIPTION
Switching the approvers/reviewers to use the team alias created. This will allow the rest of the team to stay in the loop on prototype PRs opened.